### PR TITLE
Add order payment reference and seed stripe_webhook_secret setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.4.0]
+
+### Added
+- `orders::Order` and `DbOrder` now have a `payment_reference` field (nullable, unique) for storing an external payment reference such as a Stripe Checkout Session ID or PaymentIntent ID. ([#7](https://github.com/stec-ug-haftungsbeschrankt/shopster/issues/7))
+- `Orders::get_by_payment_reference` and `DbOrder::find_by_payment_reference` for looking up an order by its payment reference, enabling webhook idempotency checks.
+- `Orders::create_from_basket` now accepts an optional `payment_reference` argument.
+- New default-settings migration seeding `stripe_webhook_secret` so every tenant has a row to read/update for verifying Stripe webhook signatures. ([#6](https://github.com/stec-ug-haftungsbeschrankt/shopster/issues/6))
+
+### Migrations
+- `2026-06-29-000000_stripe_webhook_secret`
+- `2026-06-29-010000_orders_payment_reference`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,7 +2204,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stec_shopster"
-version = "0.2.20"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-or-later"
 readme = "README.md"
 homepage = "https://stecug.de"
 repository = "https://github.com/stec-ug-haftungsbeschrankt/shopster"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/migrations/2026-06-29-000000_stripe_webhook_secret/down.sql
+++ b/migrations/2026-06-29-000000_stripe_webhook_secret/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DELETE FROM settings WHERE title = 'stripe_webhook_secret';

--- a/migrations/2026-06-29-000000_stripe_webhook_secret/up.sql
+++ b/migrations/2026-06-29-000000_stripe_webhook_secret/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+
+INSERT INTO settings (title, datatype, value) VALUES ('stripe_webhook_secret', 'String', '');

--- a/migrations/2026-06-29-010000_orders_payment_reference/down.sql
+++ b/migrations/2026-06-29-010000_orders_payment_reference/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX orders_payment_reference_idx;
+
+ALTER TABLE "orders"
+DROP COLUMN payment_reference;

--- a/migrations/2026-06-29-010000_orders_payment_reference/up.sql
+++ b/migrations/2026-06-29-010000_orders_payment_reference/up.sql
@@ -1,0 +1,5 @@
+-- Your SQL goes here
+ALTER TABLE "orders"
+ADD COLUMN payment_reference TEXT;
+
+CREATE UNIQUE INDEX orders_payment_reference_idx ON orders (payment_reference) WHERE payment_reference IS NOT NULL;

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -148,6 +148,7 @@ pub struct Order {
     pub items: Vec<OrderItemSnapshot>,
     pub created_at: NaiveDateTime,
     pub updated_at: Option<NaiveDateTime>,
+    pub payment_reference: Option<String>,
 }
 
 impl From<&Order> for DbOrder {
@@ -159,7 +160,8 @@ impl From<&Order> for DbOrder {
             delivery_address: order.delivery_address.clone(),
             billing_address: order.billing_address.clone(),
             created_at: Utc::now().naive_utc(),
-            updated_at: Some(Utc::now().naive_utc())
+            updated_at: Some(Utc::now().naive_utc()),
+            payment_reference: order.payment_reference.clone(),
         }
     }
 }
@@ -205,6 +207,7 @@ impl Orders {
                 items,
                 created_at: db_order.created_at,
                 updated_at: db_order.updated_at,
+                payment_reference: db_order.payment_reference,
             });
         }
 
@@ -225,6 +228,7 @@ impl Orders {
             items,
             created_at: db_order.created_at,
             updated_at: db_order.updated_at,
+            payment_reference: db_order.payment_reference,
         })
     }
 
@@ -245,6 +249,7 @@ impl Orders {
                 items,
                 created_at: db_order.created_at,
                 updated_at: db_order.updated_at,
+                payment_reference: db_order.payment_reference,
             });
         }
 
@@ -268,10 +273,31 @@ impl Orders {
                 items,
                 created_at: db_order.created_at,
                 updated_at: db_order.updated_at,
+                payment_reference: db_order.payment_reference,
             });
         }
 
         Ok(orders)
+    }
+
+    pub async fn get_by_payment_reference(&self, payment_reference: &str) -> Result<Option<Order>, ShopsterError> {
+        let Some(db_order) = DbOrder::find_by_payment_reference(self.tenant_id, payment_reference).await? else {
+            return Ok(None);
+        };
+        let db_items = DbOrderItem::get_for_order(self.tenant_id, db_order.id).await?;
+        let items = db_items.iter().map(OrderItemSnapshot::from).collect();
+
+        Ok(Some(Order {
+            id: db_order.id,
+            customer_id: db_order.customer_id,
+            status: db_order.status.into(),
+            delivery_address: db_order.delivery_address,
+            billing_address: db_order.billing_address,
+            items,
+            created_at: db_order.created_at,
+            updated_at: db_order.updated_at,
+            payment_reference: db_order.payment_reference,
+        }))
     }
 
     pub async fn insert(&self, order: &Order) -> Result<Order, ShopsterError> {
@@ -317,6 +343,7 @@ impl Orders {
                 items,
                 created_at: created_order.created_at,
                 updated_at: created_order.updated_at,
+                payment_reference: created_order.payment_reference,
             })
         }).await
     }
@@ -365,6 +392,7 @@ impl Orders {
                 items,
                 created_at: updated_order.created_at,
                 updated_at: updated_order.updated_at,
+                payment_reference: updated_order.payment_reference,
             })
         }).await
     }
@@ -386,7 +414,7 @@ impl Orders {
         Ok(result > 0)
     }
 
-    pub async fn create_from_basket(&self, basket_id: Uuid, delivery_address: String, billing_address: String) -> Result<Order, ShopsterError> {
+    pub async fn create_from_basket(&self, basket_id: Uuid, delivery_address: String, billing_address: String, payment_reference: Option<String>) -> Result<Order, ShopsterError> {
         let baskets = Baskets::new(self.tenant_id);
         let basket_items = baskets.get_products_with_details(basket_id).await?;
 
@@ -426,6 +454,7 @@ impl Orders {
             items,
             created_at: Utc::now().naive_utc(),
             updated_at: None,
+            payment_reference,
         };
 
         self.insert(&order).await

--- a/src/postgresql/dborder.rs
+++ b/src/postgresql/dborder.rs
@@ -99,7 +99,8 @@ pub struct DbOrder {
     pub delivery_address: String,
     pub billing_address: String,
     pub created_at: NaiveDateTime,
-    pub updated_at: Option<NaiveDateTime>
+    pub updated_at: Option<NaiveDateTime>,
+    pub payment_reference: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Insertable)]
@@ -110,7 +111,8 @@ pub struct InsertableDbOrder {
     pub delivery_address: String,
     pub billing_address: String,
     pub created_at: NaiveDateTime,
-    pub updated_at: Option<NaiveDateTime>
+    pub updated_at: Option<NaiveDateTime>,
+    pub payment_reference: Option<String>,
 }
 
 impl From<&DbOrder> for InsertableDbOrder {
@@ -121,7 +123,8 @@ impl From<&DbOrder> for InsertableDbOrder {
             delivery_address: order.delivery_address.clone(),
             billing_address: order.billing_address.clone(),
             created_at: order.created_at,
-            updated_at: order.updated_at
+            updated_at: order.updated_at,
+            payment_reference: order.payment_reference.clone(),
         }
     }
 }
@@ -260,6 +263,17 @@ impl DbOrder {
             .filter(orders::customer_id.eq(customer_id))
             .load(&mut conn).await?;
         Ok(orders)
+    }
+
+    pub async fn find_by_payment_reference(tenant_id: Uuid, payment_reference: &str) -> Result<Option<Self>, ShopsterError> {
+        let pool = aquire_pool(tenant_id).await?;
+        let mut conn = pool.get().await.map_err(|e| ShopsterError::DatabaseConnectionError(e.to_string()))?;
+
+        let order = orders::table
+            .filter(orders::payment_reference.eq(payment_reference))
+            .first(&mut conn).await
+            .optional()?;
+        Ok(order)
     }
 
     pub async fn get_without_customer_id(tenant_id: Uuid) -> Result<Vec<Self>, ShopsterError> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -69,6 +69,7 @@ diesel::table! {
         billing_address -> Text,
         created_at -> Timestamp,
         updated_at -> Nullable<Timestamp>,
+        payment_reference -> Nullable<Text>,
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -53,7 +53,7 @@ async fn settings_get_all() {
         let settings = shopster.settings(tenant.id).unwrap().get_all().await;
 
         assert!(settings.is_ok());
-        assert_eq!(13, settings.unwrap().len());
+        assert_eq!(14, settings.unwrap().len());
     }).await;
 }
 
@@ -79,6 +79,7 @@ async fn order_test() {
             items: Vec::new(),
             created_at: Default::default(),
             updated_at: None,
+            payment_reference: None,
         };
 
         let _ = orders.insert(&new_order).await.unwrap();

--- a/tests/order_tests.rs
+++ b/tests/order_tests.rs
@@ -22,6 +22,7 @@ fn make_order(status: OrderStatus) -> Order {
         items: Vec::new(),
         created_at: Utc::now().naive_utc(),
         updated_at: None,
+        payment_reference: None,
     }
 }
 
@@ -169,6 +170,7 @@ async fn order_inventory_reservation_on_insert_test() {
             }],
             created_at: Utc::now().naive_utc(),
             updated_at: None,
+            payment_reference: None,
         };
 
         let orders = shopster.orders(tenant.id).unwrap();
@@ -227,6 +229,7 @@ async fn order_reservation_released_on_shipping_test() {
             }],
             created_at: Utc::now().naive_utc(),
             updated_at: None,
+            payment_reference: None,
         };
 
         let orders = shopster.orders(tenant.id).unwrap();
@@ -282,6 +285,7 @@ async fn order_create_from_basket_test() {
             basket_id,
             "Delivery Street 5, 99999 Deliverytown".to_string(),
             "Billing Street 5, 99999 Billingtown".to_string(),
+            None,
         ).await.unwrap();
 
         assert_eq!(OrderStatus::New, order.status);
@@ -411,6 +415,7 @@ async fn order_remove_releases_reservation_test() {
             }],
             created_at: Utc::now().naive_utc(),
             updated_at: None,
+            payment_reference: None,
         };
 
         let orders = shopster.orders(tenant.id).unwrap();


### PR DESCRIPTION
## Summary
- Closes #7: adds `payment_reference` (nullable, unique) to `Order`/`DbOrder` plus `Orders::get_by_payment_reference` / `DbOrder::find_by_payment_reference`, so a Stripe Checkout Session/PaymentIntent ID can be stored and looked up for webhook idempotency. `create_from_basket` now accepts an optional `payment_reference`.
- Closes #6: new migration seeds a `stripe_webhook_secret` row in the default settings for every tenant, removing the need for callers to fall back to `Settings::insert`.
- Bumps crate version 0.3.0 → 0.4.0 and adds `CHANGELOG.md`.

## Details
- New migrations: `migrations/2026-06-29-000000_stripe_webhook_secret`, `migrations/2026-06-29-010000_orders_payment_reference`.
- Updated `src/schema.rs`, `src/postgresql/dborder.rs`, `src/orders.rs` for the new column/field.
- Updated test fixtures in `tests/order_tests.rs` and `tests/integration_test.rs` (settings count assertion moved 13 → 14; all `Order { .. }` literals updated; `create_from_basket` call sites updated).

## Test plan
- [x] `cargo build` and `cargo build --tests` succeed cleanly
- [x] `order_test` and `settings_get_all` pass individually against a Dockerized Postgres testcontainer
- [ ] Full `order_tests` suite run was flaky under heavy parallel testcontainer load (connection-refused from Docker resource contention, unrelated to this change) — re-run isolated tests confirmed correctness