### PR TITLE
Only publish to crates.io on master pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Run tests
         run: cargo nextest run --verbose
       - name: Publish to crates.io
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: cargo publish --allow-dirty


### PR DESCRIPTION
## Summary
- The crates.io publish step in the CI workflow ran unconditionally, including on PR builds and pushes to non-master branches.
- Adds a condition so `cargo publish` only runs on `push` events to `refs/heads/master`.

## Test plan
- [ ] Open a PR against master and confirm the publish step is skipped in the Actions log
- [ ] Merge to master and confirm the publish step runs