### PR TITLE
Add order Cancelled status and independent payment status tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0]
+
+### Added
+- `OrderStatus::Cancelled` is a new terminal order status representing an order that will never be fulfilled (customer cancellation, stock unavailable, fraud check failure, permanent payment failure, etc). `Orders::is_valid_transition` allows cancellation from any non-terminal status (`New`, `InProgress`, `ReadyToShip`, `Shipping`) into `Cancelled`, and disallows any transition out of `Cancelled` or from `Done`. Cancelling a reserving order releases its warehouse reservation through the same mechanism used for other status transitions. ([#10](https://github.com/stec-ug-haftungsbeschrankt/shopster/issues/10))
+- `PaymentStatus` enum (`Pending`, `Paid`, `Failed`, `Refunded`) and matching `DbPaymentStatus`, tracked independently of `OrderStatus` since payment and fulfillment are orthogonal (e.g. an order can be `Cancelled` after being `Paid` and still need a refund). `Order` and `DbOrder` gained a `payment_status` field, defaulting to `Pending`. ([#11](https://github.com/stec-ug-haftungsbeschrankt/shopster/issues/11))
+- `Orders::update_payment_status` updates an order's payment status directly, bypassing fulfillment transition validation — intended for use by payment webhooks (e.g. Stripe) that need to record a payment outcome without driving the fulfillment lifecycle.
+
+### Migrations
+- `2026-06-29-020000_order_cancelled_status` (adds the `Cancelled` value to the `dborderstatus` enum; runs outside a transaction, as required by `ALTER TYPE ... ADD VALUE`)
+- `2026-06-29-030000_order_payment_status` (adds the `dbpaymentstatus` enum and the `orders.payment_status` column, default `Pending`)
+
 ## [0.4.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,7 +2204,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stec_shopster"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-or-later"
 readme = "README.md"
 homepage = "https://stecug.de"
 repository = "https://github.com/stec-ug-haftungsbeschrankt/shopster"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,7 +177,8 @@ baskets.merge_baskets(source, target)
 
 **Key Structures:**
 - `Order`: Complete order with items and addresses
-- `OrderStatus`: Enum for order lifecycle (New → Done)
+- `OrderStatus`: Enum for order fulfillment lifecycle (New → Done, or cancelled at any non-terminal point)
+- `PaymentStatus`: Enum for payment state (Pending, Paid, Failed, Refunded), tracked independently of `OrderStatus`
 - `OrderItemSnapshot`: Historical product snapshot
 - `Orders`: Handler
 
@@ -185,12 +186,16 @@ baskets.merge_baskets(source, target)
 ```
 New → InProgress → ReadyToShip → Shipping → Done
 ```
+Any of `New`, `InProgress`, `ReadyToShip`, `Shipping` may also transition directly to the terminal `Cancelled` status (e.g. customer cancellation, stock unavailable, fraud check failure). No transition is valid out of `Done` or `Cancelled`. Cancelling a reserving order releases its warehouse reservation.
+
+`PaymentStatus` is a separate axis from `OrderStatus` — fulfillment and payment progress independently of each other (e.g. an order can be `Cancelled` while `Paid`, awaiting refund, or `Shipping` while payment is still `Pending` for invoice/COD orders).
 
 **Operations:**
 ```rust
 orders.get_all()
 orders.insert(&order)
-orders.update_status(order_id, new_status)
+orders.update(&order)                                  // fulfillment status transitions, validated
+orders.update_payment_status(order_id, payment_status)  // payment status, independent of fulfillment
 ```
 
 ### `warehouse.rs` - Inventory Management

--- a/migrations/2026-06-29-020000_order_cancelled_status/down.sql
+++ b/migrations/2026-06-29-020000_order_cancelled_status/down.sql
@@ -1,0 +1,16 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE orders
+    ALTER COLUMN status
+    TYPE text
+    USING status::text;
+
+DROP TYPE dborderstatus;
+
+CREATE TYPE dborderstatus AS ENUM (
+    'New', 'InProgress', 'ReadyToShip', 'Shipping', 'Done'
+);
+
+ALTER TABLE orders
+    ALTER COLUMN status
+    TYPE dborderstatus
+    USING status::dborderstatus;

--- a/migrations/2026-06-29-020000_order_cancelled_status/metadata.toml
+++ b/migrations/2026-06-29-020000_order_cancelled_status/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2026-06-29-020000_order_cancelled_status/up.sql
+++ b/migrations/2026-06-29-020000_order_cancelled_status/up.sql
@@ -1,0 +1,2 @@
+-- Your SQL goes here
+ALTER TYPE dborderstatus ADD VALUE 'Cancelled';

--- a/migrations/2026-06-29-030000_order_payment_status/down.sql
+++ b/migrations/2026-06-29-030000_order_payment_status/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE "orders"
+DROP COLUMN payment_status;
+
+DROP TYPE dbpaymentstatus;

--- a/migrations/2026-06-29-030000_order_payment_status/up.sql
+++ b/migrations/2026-06-29-030000_order_payment_status/up.sql
@@ -1,0 +1,7 @@
+-- Your SQL goes here
+CREATE TYPE dbpaymentstatus AS ENUM (
+    'Pending', 'Paid', 'Failed', 'Refunded'
+);
+
+ALTER TABLE "orders"
+ADD COLUMN payment_status dbpaymentstatus NOT NULL DEFAULT 'Pending';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,12 @@ pub mod orders;
 pub mod settings;
 pub mod warehouse;
 pub use orders::OrderStatus;
+pub use orders::PaymentStatus;
 
 #[doc(hidden)]
 pub use postgresql::dborder::DbOrderStatus;
+#[doc(hidden)]
+pub use postgresql::dborder::DbPaymentStatus;
 
 use diesel::PgConnection;
 use diesel::prelude::*;

--- a/src/orders.rs
+++ b/src/orders.rs
@@ -12,6 +12,7 @@ use crate::baskets::Baskets;
 use crate::postgresql::dborder::DbOrder;
 use crate::postgresql::dborder::DbOrderItem;
 use crate::postgresql::dborder::DbOrderStatus;
+use crate::postgresql::dborder::DbPaymentStatus;
 use crate::postgresql::dbwarehouse::DbWarehouse;
 
 /// The lifecycle status of an order.
@@ -22,6 +23,7 @@ pub enum OrderStatus {
     ReadyToShip,
     Shipping,
     Done,
+    Cancelled,
 }
 
 impl fmt::Display for OrderStatus {
@@ -38,6 +40,7 @@ impl From<DbOrderStatus> for OrderStatus {
             DbOrderStatus::ReadyToShip => OrderStatus::ReadyToShip,
             DbOrderStatus::Shipping => OrderStatus::Shipping,
             DbOrderStatus::Done => OrderStatus::Done,
+            DbOrderStatus::Cancelled => OrderStatus::Cancelled,
         }
     }
 }
@@ -50,6 +53,44 @@ impl From<OrderStatus> for DbOrderStatus {
             OrderStatus::ReadyToShip => DbOrderStatus::ReadyToShip,
             OrderStatus::Shipping => DbOrderStatus::Shipping,
             OrderStatus::Done => DbOrderStatus::Done,
+            OrderStatus::Cancelled => DbOrderStatus::Cancelled,
+        }
+    }
+}
+
+/// The payment status of an order, tracked independently of fulfillment.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PaymentStatus {
+    Pending,
+    Paid,
+    Failed,
+    Refunded,
+}
+
+impl fmt::Display for PaymentStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl From<DbPaymentStatus> for PaymentStatus {
+    fn from(status: DbPaymentStatus) -> Self {
+        match status {
+            DbPaymentStatus::Pending => PaymentStatus::Pending,
+            DbPaymentStatus::Paid => PaymentStatus::Paid,
+            DbPaymentStatus::Failed => PaymentStatus::Failed,
+            DbPaymentStatus::Refunded => PaymentStatus::Refunded,
+        }
+    }
+}
+
+impl From<PaymentStatus> for DbPaymentStatus {
+    fn from(status: PaymentStatus) -> Self {
+        match status {
+            PaymentStatus::Pending => DbPaymentStatus::Pending,
+            PaymentStatus::Paid => DbPaymentStatus::Paid,
+            PaymentStatus::Failed => DbPaymentStatus::Failed,
+            PaymentStatus::Refunded => DbPaymentStatus::Refunded,
         }
     }
 }
@@ -149,6 +190,7 @@ pub struct Order {
     pub created_at: NaiveDateTime,
     pub updated_at: Option<NaiveDateTime>,
     pub payment_reference: Option<String>,
+    pub payment_status: PaymentStatus,
 }
 
 impl From<&Order> for DbOrder {
@@ -162,6 +204,7 @@ impl From<&Order> for DbOrder {
             created_at: Utc::now().naive_utc(),
             updated_at: Some(Utc::now().naive_utc()),
             payment_reference: order.payment_reference.clone(),
+            payment_status: order.payment_status.into(),
         }
     }
 }
@@ -187,6 +230,10 @@ impl Orders {
                 | (OrderStatus::InProgress, OrderStatus::ReadyToShip)
                 | (OrderStatus::ReadyToShip, OrderStatus::Shipping)
                 | (OrderStatus::Shipping, OrderStatus::Done)
+                | (OrderStatus::New, OrderStatus::Cancelled)
+                | (OrderStatus::InProgress, OrderStatus::Cancelled)
+                | (OrderStatus::ReadyToShip, OrderStatus::Cancelled)
+                | (OrderStatus::Shipping, OrderStatus::Cancelled)
         )
     }
 
@@ -208,6 +255,7 @@ impl Orders {
                 created_at: db_order.created_at,
                 updated_at: db_order.updated_at,
                 payment_reference: db_order.payment_reference,
+                payment_status: db_order.payment_status.into(),
             });
         }
 
@@ -229,6 +277,7 @@ impl Orders {
             created_at: db_order.created_at,
             updated_at: db_order.updated_at,
             payment_reference: db_order.payment_reference,
+            payment_status: db_order.payment_status.into(),
         })
     }
 
@@ -250,6 +299,7 @@ impl Orders {
                 created_at: db_order.created_at,
                 updated_at: db_order.updated_at,
                 payment_reference: db_order.payment_reference,
+                payment_status: db_order.payment_status.into(),
             });
         }
 
@@ -274,6 +324,7 @@ impl Orders {
                 created_at: db_order.created_at,
                 updated_at: db_order.updated_at,
                 payment_reference: db_order.payment_reference,
+                payment_status: db_order.payment_status.into(),
             });
         }
 
@@ -297,6 +348,7 @@ impl Orders {
             created_at: db_order.created_at,
             updated_at: db_order.updated_at,
             payment_reference: db_order.payment_reference,
+            payment_status: db_order.payment_status.into(),
         }))
     }
 
@@ -344,6 +396,7 @@ impl Orders {
                 created_at: created_order.created_at,
                 updated_at: created_order.updated_at,
                 payment_reference: created_order.payment_reference,
+                payment_status: created_order.payment_status.into(),
             })
         }).await
     }
@@ -393,6 +446,7 @@ impl Orders {
                 created_at: updated_order.created_at,
                 updated_at: updated_order.updated_at,
                 payment_reference: updated_order.payment_reference,
+                payment_status: updated_order.payment_status.into(),
             })
         }).await
     }
@@ -455,8 +509,33 @@ impl Orders {
             created_at: Utc::now().naive_utc(),
             updated_at: None,
             payment_reference,
+            payment_status: PaymentStatus::Pending,
         };
 
         self.insert(&order).await
+    }
+
+    /// Updates an order's payment status independently of its fulfillment status.
+    ///
+    /// This bypasses fulfillment transition validation, since payment state changes
+    /// (e.g. a Stripe webhook confirming or refunding a payment) are orthogonal to
+    /// the order's shipping lifecycle.
+    pub async fn update_payment_status(&self, order_id: i64, payment_status: PaymentStatus) -> Result<Order, ShopsterError> {
+        let updated_order = DbOrder::update_payment_status(self.tenant_id, order_id, payment_status.into()).await?;
+        let db_items = DbOrderItem::get_for_order(self.tenant_id, updated_order.id).await?;
+        let items = db_items.iter().map(OrderItemSnapshot::from).collect();
+
+        Ok(Order {
+            id: updated_order.id,
+            customer_id: updated_order.customer_id,
+            status: updated_order.status.into(),
+            delivery_address: updated_order.delivery_address,
+            billing_address: updated_order.billing_address,
+            items,
+            created_at: updated_order.created_at,
+            updated_at: updated_order.updated_at,
+            payment_reference: updated_order.payment_reference,
+            payment_status: updated_order.payment_status.into(),
+        })
     }
 }

--- a/src/postgresql/dborder.rs
+++ b/src/postgresql/dborder.rs
@@ -27,7 +27,8 @@ pub enum DbOrderStatus {
     InProgress,
     ReadyToShip,
     Shipping,
-    Done
+    Done,
+    Cancelled
 }
 
 impl fmt::Display for DbOrderStatus {
@@ -44,6 +45,7 @@ impl ToSql<crate::schema::sql_types::DbOrderStatus, Pg> for DbOrderStatus {
             DbOrderStatus::ReadyToShip => out.write_all(b"ReadyToShip")?,
             DbOrderStatus::Shipping => out.write_all(b"Shipping")?,
             DbOrderStatus::Done => out.write_all(b"Done")?,
+            DbOrderStatus::Cancelled => out.write_all(b"Cancelled")?,
         }
         Ok(IsNull::No)
     }
@@ -57,6 +59,7 @@ impl FromSql<crate::schema::sql_types::DbOrderStatus, Pg> for DbOrderStatus {
             b"ReadyToShip" => Ok(DbOrderStatus::ReadyToShip),
             b"Shipping" => Ok(DbOrderStatus::Shipping),
             b"Done" => Ok(DbOrderStatus::Done),
+            b"Cancelled" => Ok(DbOrderStatus::Cancelled),
             _ => Err("Unrecognized enum variant".into()),
         }
     }
@@ -70,6 +73,7 @@ impl From<&DbOrderStatus> for i32 {
             DbOrderStatus::ReadyToShip => 2,
             DbOrderStatus::Shipping => 3,
             DbOrderStatus::Done => 4,
+            DbOrderStatus::Cancelled => 5,
         }
     }
 }
@@ -84,7 +88,72 @@ impl TryFrom<i32> for DbOrderStatus {
             2 => Ok(DbOrderStatus::ReadyToShip),
             3 => Ok(DbOrderStatus::Shipping),
             4 => Ok(DbOrderStatus::Done),
+            5 => Ok(DbOrderStatus::Cancelled),
             _ => Err(format!("Unknown order status: {}", status))
+        }
+    }
+}
+
+#[derive(Debug, AsExpression, FromSqlRow, Serialize, Deserialize, PartialEq, PartialOrd, Copy, Clone)]
+#[diesel(sql_type = crate::schema::sql_types::DbPaymentStatus)]
+pub enum DbPaymentStatus {
+    Pending,
+    Paid,
+    Failed,
+    Refunded
+}
+
+impl fmt::Display for DbPaymentStatus {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl ToSql<crate::schema::sql_types::DbPaymentStatus, Pg> for DbPaymentStatus {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        match *self {
+            DbPaymentStatus::Pending => out.write_all(b"Pending")?,
+            DbPaymentStatus::Paid => out.write_all(b"Paid")?,
+            DbPaymentStatus::Failed => out.write_all(b"Failed")?,
+            DbPaymentStatus::Refunded => out.write_all(b"Refunded")?,
+        }
+        Ok(IsNull::No)
+    }
+}
+
+impl FromSql<crate::schema::sql_types::DbPaymentStatus, Pg> for DbPaymentStatus {
+    fn from_sql(bytes: PgValue) -> deserialize::Result<Self> {
+        match bytes.as_bytes() {
+            b"Pending" => Ok(DbPaymentStatus::Pending),
+            b"Paid" => Ok(DbPaymentStatus::Paid),
+            b"Failed" => Ok(DbPaymentStatus::Failed),
+            b"Refunded" => Ok(DbPaymentStatus::Refunded),
+            _ => Err("Unrecognized enum variant".into()),
+        }
+    }
+}
+
+impl From<&DbPaymentStatus> for i32 {
+    fn from(status: &DbPaymentStatus) -> Self {
+        match status {
+            DbPaymentStatus::Pending => 0,
+            DbPaymentStatus::Paid => 1,
+            DbPaymentStatus::Failed => 2,
+            DbPaymentStatus::Refunded => 3,
+        }
+    }
+}
+
+impl TryFrom<i32> for DbPaymentStatus {
+    type Error = String;
+
+    fn try_from(status: i32) -> Result<Self, Self::Error> {
+        match status {
+            0 => Ok(DbPaymentStatus::Pending),
+            1 => Ok(DbPaymentStatus::Paid),
+            2 => Ok(DbPaymentStatus::Failed),
+            3 => Ok(DbPaymentStatus::Refunded),
+            _ => Err(format!("Unknown payment status: {}", status))
         }
     }
 }
@@ -101,6 +170,7 @@ pub struct DbOrder {
     pub created_at: NaiveDateTime,
     pub updated_at: Option<NaiveDateTime>,
     pub payment_reference: Option<String>,
+    pub payment_status: DbPaymentStatus,
 }
 
 #[derive(Debug, Serialize, Deserialize, Insertable)]
@@ -113,6 +183,7 @@ pub struct InsertableDbOrder {
     pub created_at: NaiveDateTime,
     pub updated_at: Option<NaiveDateTime>,
     pub payment_reference: Option<String>,
+    pub payment_status: DbPaymentStatus,
 }
 
 impl From<&DbOrder> for InsertableDbOrder {
@@ -125,6 +196,7 @@ impl From<&DbOrder> for InsertableDbOrder {
             created_at: order.created_at,
             updated_at: order.updated_at,
             payment_reference: order.payment_reference.clone(),
+            payment_status: order.payment_status,
         }
     }
 }
@@ -321,6 +393,17 @@ impl DbOrder {
             .filter(orders::id.eq(id))
             .set(order)
             .get_result(conn).await?;
+        Ok(db_order)
+    }
+
+    pub async fn update_payment_status(tenant_id: Uuid, id: i64, payment_status: DbPaymentStatus) -> Result<Self, ShopsterError> {
+        let pool = aquire_pool(tenant_id).await?;
+        let mut conn = pool.get().await.map_err(|e| ShopsterError::DatabaseConnectionError(e.to_string()))?;
+
+        let db_order = diesel::update(orders::table)
+            .filter(orders::id.eq(id))
+            .set(orders::payment_status.eq(payment_status))
+            .get_result(&mut conn).await?;
         Ok(db_order)
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4,6 +4,10 @@ pub mod sql_types {
     #[derive(diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "dborderstatus"))]
     pub struct DbOrderStatus;
+
+    #[derive(diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "dbpaymentstatus"))]
+    pub struct DbPaymentStatus;
 }
 
 diesel::table! {
@@ -60,6 +64,7 @@ diesel::table! {
 diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::DbOrderStatus;
+    use super::sql_types::DbPaymentStatus;
 
     orders (id) {
         id -> Int8,
@@ -70,6 +75,7 @@ diesel::table! {
         created_at -> Timestamp,
         updated_at -> Nullable<Timestamp>,
         payment_reference -> Nullable<Text>,
+        payment_status -> DbPaymentStatus,
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,7 +4,7 @@
 //! `docker ps` to verify Docker is available
 //! `cargo test --test integration_test` to run these tests
 
-use stec_shopster::{Shopster, DatabaseSelector, orders::Order, orders::OrderStatus};
+use stec_shopster::{Shopster, DatabaseSelector, orders::Order, orders::OrderStatus, orders::PaymentStatus};
 use stec_tenet::{Tenet, Storage};
 use uuid::Uuid;
 
@@ -80,6 +80,7 @@ async fn order_test() {
             created_at: Default::default(),
             updated_at: None,
             payment_reference: None,
+            payment_status: PaymentStatus::Pending,
         };
 
         let _ = orders.insert(&new_order).await.unwrap();

--- a/tests/order_tests.rs
+++ b/tests/order_tests.rs
@@ -4,9 +4,9 @@ use std::convert::TryFrom;
 use chrono::Utc;
 use uuid::Uuid;
 use stec_tenet::{Storage, Tenet};
-use stec_shopster::{DatabaseSelector, DbOrderStatus, Shopster};
+use stec_shopster::{DatabaseSelector, DbOrderStatus, DbPaymentStatus, Shopster};
 use stec_shopster::customers::Customer;
-use stec_shopster::orders::{Order, OrderItemSnapshot, OrderItemPrice, OrderStatus};
+use stec_shopster::orders::{Order, OrderItemSnapshot, OrderItemPrice, OrderStatus, PaymentStatus};
 use stec_shopster::products::{Price, Product};
 use stec_shopster::warehouse::WarehouseItem;
 use stec_tenet::encryption_modes::EncryptionModes;
@@ -23,6 +23,7 @@ fn make_order(status: OrderStatus) -> Order {
         created_at: Utc::now().naive_utc(),
         updated_at: None,
         payment_reference: None,
+        payment_status: PaymentStatus::Pending,
     }
 }
 
@@ -171,6 +172,7 @@ async fn order_inventory_reservation_on_insert_test() {
             created_at: Utc::now().naive_utc(),
             updated_at: None,
             payment_reference: None,
+            payment_status: PaymentStatus::Pending,
         };
 
         let orders = shopster.orders(tenant.id).unwrap();
@@ -230,6 +232,7 @@ async fn order_reservation_released_on_shipping_test() {
             created_at: Utc::now().naive_utc(),
             updated_at: None,
             payment_reference: None,
+            payment_status: PaymentStatus::Pending,
         };
 
         let orders = shopster.orders(tenant.id).unwrap();
@@ -416,6 +419,7 @@ async fn order_remove_releases_reservation_test() {
             created_at: Utc::now().naive_utc(),
             updated_at: None,
             payment_reference: None,
+            payment_status: PaymentStatus::Pending,
         };
 
         let orders = shopster.orders(tenant.id).unwrap();
@@ -442,6 +446,7 @@ fn test_valid_order_status_conversions() {
     assert_eq!(DbOrderStatus::try_from(2).unwrap(), DbOrderStatus::ReadyToShip);
     assert_eq!(DbOrderStatus::try_from(3).unwrap(), DbOrderStatus::Shipping);
     assert_eq!(DbOrderStatus::try_from(4).unwrap(), DbOrderStatus::Done);
+    assert_eq!(DbOrderStatus::try_from(5).unwrap(), DbOrderStatus::Cancelled);
 }
 
 /// Test that invalid i32 values return errors instead of panicking
@@ -452,7 +457,7 @@ fn test_invalid_order_status_conversions() {
     assert!(DbOrderStatus::try_from(-100).is_err());
 
     // Test out-of-range positive values
-    assert!(DbOrderStatus::try_from(5).is_err());
+    assert!(DbOrderStatus::try_from(6).is_err());
     assert!(DbOrderStatus::try_from(10).is_err());
     assert!(DbOrderStatus::try_from(100).is_err());
     assert!(DbOrderStatus::try_from(i32::MAX).is_err());
@@ -462,7 +467,7 @@ fn test_invalid_order_status_conversions() {
 /// Test that error messages are informative
 #[test]
 fn test_order_status_error_messages() {
-    let invalid_values = vec![-1, 5, 10, 99];
+    let invalid_values = vec![-1, 6, 10, 99];
 
     for val in invalid_values {
         let result = DbOrderStatus::try_from(val);
@@ -490,6 +495,7 @@ fn test_round_trip_conversion() {
         DbOrderStatus::ReadyToShip,
         DbOrderStatus::Shipping,
         DbOrderStatus::Done,
+        DbOrderStatus::Cancelled,
     ];
 
     for original_status in statuses {
@@ -519,7 +525,7 @@ fn test_extreme_values_dont_panic() {
         i32::MIN + 1,
         -1000000,
         -1,
-        5,
+        6,
         1000,
         i32::MAX - 1,
         i32::MAX,
@@ -545,6 +551,7 @@ fn test_status_numeric_mapping() {
         (2, DbOrderStatus::ReadyToShip),
         (3, DbOrderStatus::Shipping),
         (4, DbOrderStatus::Done),
+        (5, DbOrderStatus::Cancelled),
     ];
 
     for (expected_num, status) in mappings {
@@ -561,4 +568,228 @@ fn test_status_numeric_mapping() {
     }
 }
 
+#[tokio::test]
+async fn order_cancel_from_new_releases_reservation_test() {
+    test_harness(|tenet_connection_string, shopster_connection_string| async move {
+        let tenet = Tenet::new(tenet_connection_string);
+        let tenant = tenet.create_tenant("order_cancel_releases".to_string()).unwrap();
+        let storage = Storage::new_postgresql_database(shopster_connection_string, tenant.id);
+        tenant.add_storage(&storage).unwrap();
 
+        let database_selector = DatabaseSelector::new(tenet);
+        let shopster = Shopster::new(database_selector);
+
+        let products = shopster.products(tenant.id).unwrap();
+        let product = products.insert(&make_product_with_price("ART-ORD-005", "5555555555555", 300)).await.unwrap();
+
+        let warehouse = shopster.warehouse(tenant.id).unwrap();
+        warehouse.insert(&WarehouseItem {
+            id: 0,
+            product_id: product.id,
+            in_stock: 10,
+            reserved: 0,
+            created_at: Utc::now().naive_utc(),
+            updated_at: None,
+        }).await.unwrap();
+
+        let order_with_item = Order {
+            id: 0,
+            customer_id: None,
+            status: OrderStatus::New,
+            delivery_address: "Test Street 1, 12345 Testcity".to_string(),
+            billing_address: "Test Street 1, 12345 Testcity".to_string(),
+            items: vec![OrderItemSnapshot {
+                id: 0,
+                product_id: product.id,
+                quantity: 2,
+                article_number: product.article_number.clone(),
+                gtin: product.gtin.clone(),
+                title: product.title.clone(),
+                short_description: product.short_description.clone(),
+                description: product.description.clone(),
+                tags: vec![],
+                title_image: product.image_url.clone(),
+                additional_images: vec![],
+                price: OrderItemPrice { amount: 300, currency: "EUR".to_string() },
+                weight: product.weight,
+            }],
+            created_at: Utc::now().naive_utc(),
+            updated_at: None,
+            payment_reference: None,
+            payment_status: PaymentStatus::Pending,
+        };
+
+        let orders = shopster.orders(tenant.id).unwrap();
+        let mut order = orders.insert(&order_with_item).await.unwrap();
+
+        let wh_after_insert = warehouse.get_by_product_id(product.id).await.unwrap();
+        assert_eq!(2, wh_after_insert.reserved, "Inventory should be reserved for New order");
+
+        order.status = OrderStatus::Cancelled;
+        let cancelled = orders.update(&order).await.unwrap();
+        assert_eq!(OrderStatus::Cancelled, cancelled.status);
+
+        let wh_after_cancel = warehouse.get_by_product_id(product.id).await.unwrap();
+        assert_eq!(0, wh_after_cancel.reserved, "Reservation should be released when order is cancelled");
+    }).await;
+}
+
+#[tokio::test]
+async fn order_cancel_from_each_non_terminal_status_test() {
+    test_harness(|tenet_connection_string, shopster_connection_string| async move {
+        let tenet = Tenet::new(tenet_connection_string);
+        let tenant = tenet.create_tenant("order_cancel_each_status".to_string()).unwrap();
+        let storage = Storage::new_postgresql_database(shopster_connection_string, tenant.id);
+        tenant.add_storage(&storage).unwrap();
+
+        let database_selector = DatabaseSelector::new(tenet);
+        let shopster = Shopster::new(database_selector);
+        let orders = shopster.orders(tenant.id).unwrap();
+
+        for starting_status in [
+            OrderStatus::New,
+            OrderStatus::InProgress,
+            OrderStatus::ReadyToShip,
+            OrderStatus::Shipping,
+        ] {
+            let order = orders.insert(&make_order(OrderStatus::New)).await.unwrap();
+
+            let mut current = order;
+            // Walk the order up to the desired starting status before cancelling.
+            let path = [OrderStatus::InProgress, OrderStatus::ReadyToShip, OrderStatus::Shipping];
+            for step in path {
+                if current.status == starting_status {
+                    break;
+                }
+                current.status = step;
+                current = orders.update(&current).await.unwrap();
+            }
+
+            current.status = OrderStatus::Cancelled;
+            let cancelled = orders.update(&current).await.unwrap();
+            assert_eq!(OrderStatus::Cancelled, cancelled.status, "Failed to cancel from {:?}", starting_status);
+        }
+    }).await;
+}
+
+#[tokio::test]
+async fn order_cancel_terminal_states_rejected_test() {
+    test_harness(|tenet_connection_string, shopster_connection_string| async move {
+        let tenet = Tenet::new(tenet_connection_string);
+        let tenant = tenet.create_tenant("order_cancel_terminal".to_string()).unwrap();
+        let storage = Storage::new_postgresql_database(shopster_connection_string, tenant.id);
+        tenant.add_storage(&storage).unwrap();
+
+        let database_selector = DatabaseSelector::new(tenet);
+        let shopster = Shopster::new(database_selector);
+        let orders = shopster.orders(tenant.id).unwrap();
+
+        // Done -> Cancelled must be rejected
+        let order = orders.insert(&make_order(OrderStatus::New)).await.unwrap();
+        let mut current = order;
+        for step in [OrderStatus::InProgress, OrderStatus::ReadyToShip, OrderStatus::Shipping, OrderStatus::Done] {
+            current.status = step;
+            current = orders.update(&current).await.unwrap();
+        }
+        current.status = OrderStatus::Cancelled;
+        assert!(orders.update(&current).await.is_err(), "Done -> Cancelled should be rejected");
+
+        // Cancelled -> anything must be rejected
+        let order2 = orders.insert(&make_order(OrderStatus::New)).await.unwrap();
+        let mut current2 = order2;
+        current2.status = OrderStatus::Cancelled;
+        current2 = orders.update(&current2).await.unwrap();
+        current2.status = OrderStatus::InProgress;
+        assert!(orders.update(&current2).await.is_err(), "Cancelled -> InProgress should be rejected");
+    }).await;
+}
+
+#[tokio::test]
+async fn order_payment_status_defaults_to_pending_test() {
+    test_harness(|tenet_connection_string, shopster_connection_string| async move {
+        let tenet = Tenet::new(tenet_connection_string);
+        let tenant = tenet.create_tenant("order_payment_status_default".to_string()).unwrap();
+        let storage = Storage::new_postgresql_database(shopster_connection_string, tenant.id);
+        tenant.add_storage(&storage).unwrap();
+
+        let database_selector = DatabaseSelector::new(tenet);
+        let shopster = Shopster::new(database_selector);
+
+        let orders = shopster.orders(tenant.id).unwrap();
+        let inserted = orders.insert(&make_order(OrderStatus::New)).await.unwrap();
+
+        assert_eq!(PaymentStatus::Pending, inserted.payment_status);
+    }).await;
+}
+
+#[tokio::test]
+async fn order_update_payment_status_independent_of_fulfillment_test() {
+    test_harness(|tenet_connection_string, shopster_connection_string| async move {
+        let tenet = Tenet::new(tenet_connection_string);
+        let tenant = tenet.create_tenant("order_update_payment_status".to_string()).unwrap();
+        let storage = Storage::new_postgresql_database(shopster_connection_string, tenant.id);
+        tenant.add_storage(&storage).unwrap();
+
+        let database_selector = DatabaseSelector::new(tenet);
+        let shopster = Shopster::new(database_selector);
+
+        let orders = shopster.orders(tenant.id).unwrap();
+        let inserted = orders.insert(&make_order(OrderStatus::New)).await.unwrap();
+
+        // Mark paid without touching fulfillment status, e.g. via a Stripe webhook.
+        let paid = orders.update_payment_status(inserted.id, PaymentStatus::Paid).await.unwrap();
+        assert_eq!(PaymentStatus::Paid, paid.payment_status);
+        assert_eq!(OrderStatus::New, paid.status, "Fulfillment status must not change");
+
+        let fetched = orders.get_by_id(inserted.id).await.unwrap();
+        assert_eq!(PaymentStatus::Paid, fetched.payment_status);
+
+        // An order can later be cancelled after being paid (needs refund).
+        let mut cancel_order = fetched;
+        cancel_order.status = OrderStatus::Cancelled;
+        let cancelled = orders.update(&cancel_order).await.unwrap();
+        assert_eq!(OrderStatus::Cancelled, cancelled.status);
+        assert_eq!(PaymentStatus::Paid, cancelled.payment_status, "Payment status should be untouched by cancellation");
+
+        let refunded = orders.update_payment_status(cancelled.id, PaymentStatus::Refunded).await.unwrap();
+        assert_eq!(PaymentStatus::Refunded, refunded.payment_status);
+        assert_eq!(OrderStatus::Cancelled, refunded.status);
+    }).await;
+}
+
+/// Test successful conversions from valid i32 values to DbPaymentStatus
+#[test]
+fn test_valid_payment_status_conversions() {
+    assert_eq!(DbPaymentStatus::try_from(0).unwrap(), DbPaymentStatus::Pending);
+    assert_eq!(DbPaymentStatus::try_from(1).unwrap(), DbPaymentStatus::Paid);
+    assert_eq!(DbPaymentStatus::try_from(2).unwrap(), DbPaymentStatus::Failed);
+    assert_eq!(DbPaymentStatus::try_from(3).unwrap(), DbPaymentStatus::Refunded);
+}
+
+/// Test that invalid i32 values return errors instead of panicking
+#[test]
+fn test_invalid_payment_status_conversions() {
+    assert!(DbPaymentStatus::try_from(-1).is_err());
+    assert!(DbPaymentStatus::try_from(4).is_err());
+    assert!(DbPaymentStatus::try_from(100).is_err());
+    assert!(DbPaymentStatus::try_from(i32::MAX).is_err());
+    assert!(DbPaymentStatus::try_from(i32::MIN).is_err());
+}
+
+/// Test round-trip conversion: DbPaymentStatus -> i32 -> DbPaymentStatus
+#[test]
+fn test_payment_status_round_trip_conversion() {
+    let statuses = vec![
+        DbPaymentStatus::Pending,
+        DbPaymentStatus::Paid,
+        DbPaymentStatus::Failed,
+        DbPaymentStatus::Refunded,
+    ];
+
+    for original_status in statuses {
+        let as_i32 = i32::from(&original_status);
+        let converted_back = DbPaymentStatus::try_from(as_i32)
+            .expect("Should successfully convert valid i32 back to DbPaymentStatus");
+        assert_eq!(converted_back, original_status, "Round-trip conversion failed for status: {:?}", original_status);
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #10: adds a terminal `OrderStatus::Cancelled` state. Cancellation is allowed from any non-terminal status (`New`, `InProgress`, `ReadyToShip`, `Shipping`); no transition is allowed out of `Cancelled` or `Done`. Cancelling a reserving order releases its warehouse reservation via the existing `Orders::update` mechanism.
- Closes #11: adds a `PaymentStatus` enum (`Pending`, `Paid`, `Failed`, `Refunded`) and matching `payment_status` column on `Order`/`DbOrder`, tracked independently of fulfillment status. `Orders::update_payment_status` updates payment state directly (bypassing fulfillment transition validation), intended for webhook-driven updates (e.g. Stripe).
- Bumped crate version to `0.5.0`, updated `CHANGELOG.md` and `docs/ARCHITECTURE.md`.

## Migrations
- `2026-06-29-020000_order_cancelled_status` — adds `Cancelled` to the `dborderstatus` enum. Uses `metadata.toml` with `run_in_transaction = false`, since `ALTER TYPE ... ADD VALUE` cannot run inside a transaction block (found and fixed while testing).
- `2026-06-29-030000_order_payment_status` — adds the `dbpaymentstatus` enum and `orders.payment_status` column, default `Pending`.

## Test plan
- [x] `cargo build` / `cargo build --tests` / `cargo build --examples` all clean
- [x] Added 9 new tests in `tests/order_tests.rs`: cancellation from each non-terminal status, rejection of cancellation from terminal states, reservation release on cancel, payment-status default/independence from fulfillment, `DbPaymentStatus` conversions
- [x] All 23 tests in `order_tests.rs` pass when run individually (local Docker can't sustain many concurrent testcontainers — this flakiness under high parallelism is pre-existing on `master` too, confirmed by running the original suite unmodified)