### PR TITLE
Speed up CI: cache cargo and use cargo-binstall for nextest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - uses: cargo-bins/cargo-binstall@main
+      - name: Install nextest
+        run: cargo binstall --no-confirm cargo-nextest
       - name: Build
         run: cargo build --verbose
-      - name: Install nextest
-        run: cargo install cargo-nextest --locked
       - name: Run tests
         run: cargo nextest run --verbose
       - name: Publish to crates.io


### PR DESCRIPTION
## Summary
- The CI test job took 3+ minutes, largely because `cargo install cargo-nextest --locked` compiled nextest from source on every run.
- Adds `cargo-bins/cargo-binstall` to fetch a prebuilt `cargo-nextest` binary instead of compiling it.
- Adds `Swatinem/rust-cache@v2` to cache the Cargo registry and `target/` directory across runs, avoiding full dependency recompiles.

## Test plan
- [ ] Confirm the `build` workflow run on this PR completes successfully
- [ ] Compare total job duration against the previous 3+ minute baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)