### PR TITLE
Share Postgres containers across tests instead of one pair per test

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,21 +1,52 @@
+use tokio::sync::OnceCell;
+use uuid::Uuid;
 use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::ContainerAsync;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+/// Holds the two Postgres containers (tenet + shopster) shared by every test
+/// in this binary. Started once on first use and kept alive for the lifetime
+/// of the process; individual tests get isolation via a fresh tenant/database
+/// inside these containers rather than a container of their own.
+struct SharedContainers {
+    tenet_connection_string: String,
+    shopster_host_port: u16,
+    _tenet_node: ContainerAsync<Postgres>,
+    _shopster_node: ContainerAsync<Postgres>,
+}
+
+static SHARED_CONTAINERS: OnceCell<SharedContainers> = OnceCell::const_new();
+
+async fn shared_containers() -> &'static SharedContainers {
+    SHARED_CONTAINERS.get_or_init(|| async {
+        let tenet_node = Postgres::default().start().await.expect("Unable to create tenet container");
+        let tenet_connection_string = format!("postgres://postgres:postgres@127.0.0.1:{}/postgres", tenet_node.get_host_port_ipv4(5432).await.unwrap());
+
+        let shopster_node = Postgres::default().start().await.expect("Unable to create shopster container");
+        let shopster_host_port = shopster_node.get_host_port_ipv4(5432).await.unwrap();
+
+        SharedContainers {
+            tenet_connection_string,
+            shopster_host_port,
+            _tenet_node: tenet_node,
+            _shopster_node: shopster_node,
+        }
+    }).await
+}
+
+fn unique_shopster_database_url(host_port: u16) -> String {
+    format!("postgres://postgres:postgres@127.0.0.1:{}/stec_shopster_test_{}", host_port, Uuid::new_v4().simple())
+}
 
 pub async fn test_harness<F, Fut>(test_code: F)
 where
     F: FnOnce(String, String) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
-    let tenet_node = Postgres::default().start().await.expect("Unable to create tenet container");
-    let tenet_connection_string = format!("postgres://postgres:postgres@127.0.0.1:{}/postgres", tenet_node.get_host_port_ipv4(5432).await.unwrap());
+    let shared = shared_containers().await;
+    let shopster_connection_string = unique_shopster_database_url(shared.shopster_host_port);
 
-    let shopster_node = Postgres::default().start().await.expect("Unable to create shopster container");
-    let shopster_connection_string = format!("postgres://postgres:postgres@127.0.0.1:{}/stec_shopster_test", shopster_node.get_host_port_ipv4(5432).await.unwrap());
-
-    test_code(tenet_connection_string, shopster_connection_string).await;
-
-    shopster_node.stop().await.expect("Failed to stop shopster");
-    tenet_node.stop().await.expect("Failed to stop tenet");
+    test_code(shared.tenet_connection_string.clone(), shopster_connection_string).await;
 }
 
 pub async fn test_harness_two_tenants<F, Fut>(test_code: F)
@@ -23,18 +54,9 @@ where
     F: FnOnce(String, String, String) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
-    let tenet_node = Postgres::default().start().await.expect("Unable to create tenet container");
-    let tenet_connection_string = format!("postgres://postgres:postgres@127.0.0.1:{}/postgres", tenet_node.get_host_port_ipv4(5432).await.unwrap());
+    let shared = shared_containers().await;
+    let shopster_connection_string1 = unique_shopster_database_url(shared.shopster_host_port);
+    let shopster_connection_string2 = unique_shopster_database_url(shared.shopster_host_port);
 
-    let shopster_node1 = Postgres::default().start().await.expect("Unable to create shopster container 1");
-    let shopster_connection_string1 = format!("postgres://postgres:postgres@127.0.0.1:{}/stec_shopster_test1", shopster_node1.get_host_port_ipv4(5432).await.unwrap());
-
-    let shopster_node2 = Postgres::default().start().await.expect("Unable to create shopster container 2");
-    let shopster_connection_string2 = format!("postgres://postgres:postgres@127.0.0.1:{}/stec_shopster_test2", shopster_node2.get_host_port_ipv4(5432).await.unwrap());
-
-    test_code(tenet_connection_string, shopster_connection_string1, shopster_connection_string2).await;
-
-    shopster_node2.stop().await.expect("Failed to stop shopster tenant 2");
-    shopster_node1.stop().await.expect("Failed to stop shopster tenant 1");
-    tenet_node.stop().await.expect("Failed to stop tenet");
+    test_code(shared.tenet_connection_string.clone(), shopster_connection_string1, shopster_connection_string2).await;
 }


### PR DESCRIPTION
## Summary
- Tests using `tests/common::test_harness` / `test_harness_two_tenants` each spun up their own pair of tenet/shopster Postgres containers and tore them down afterward — for `order_tests.rs`'s 23 tests that's ~46 containers per run.
- Reworked `tests/common/mod.rs` to lazily start one tenet container and one shopster container per test binary (via `tokio::sync::OnceCell`), kept alive for the whole process. Each test now creates its own database inside the shared shopster container (`DatabaseSelector` already creates databases on demand), so tests stay isolated from each other without needing a dedicated container.
- `test_harness_two_tenants` now allocates two unique databases inside the same shared shopster container instead of two separate containers.

This cuts container churn for the `order_tests.rs` run from ~46 down to 2, and benefits `customer_tests.rs`, `baskets_tests.rs`, and `warehouse_tests.rs` too since they share the same harness.

## Test plan
- [x] `cargo test --test order_tests` — all 23 tests pass; `docker ps -a` shows exactly 2 Postgres containers for the whole run.
- [x] `cargo test --test customer_tests --test baskets_tests --test warehouse_tests` — all pass.
- Note: `tests/integration_test.rs` has its own separate, unmodified harness and is out of scope for this change. It has a pre-existing, unrelated flaky test (`settings_get_all`) caused by a global `OnceLock` in the `stec_tenet` crate racing across per-test containers — filed upstream as [stec-ug-haftungsbeschrankt/tenet#7](https://github.com/stec-ug-haftungsbeschrankt/tenet/issues/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)