### PR TITLE
CI: drop redundant debug build step before nextest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,7 @@ jobs:
       - uses: cargo-bins/cargo-binstall@main
       - name: Install nextest
         run: cargo binstall --no-confirm cargo-nextest
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
+      - name: Build and run tests
         run: cargo nextest run --verbose
       - name: Publish to crates.io
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Summary
- The CI workflow ran `cargo build --verbose`, then `cargo nextest run` (which itself builds the lib and test binaries), then `cargo publish` (which does its own release build for the crates.io upload). That's effectively two dev-profile builds of the same crate back to back.
- `cargo nextest run` already compiles everything it needs (lib + integration test binaries) before running, so the standalone `cargo build` step was pure overhead.
- Dropped the separate build step; `cargo nextest run --verbose` now builds and runs tests in one step. The release build performed by `cargo publish` for the crates.io upload is untouched, so the publish path still gets a proper release build.

Verified locally with `cargo clean && cargo nextest run --verbose` — builds cleanly from scratch and all 65 tests pass without a preceding `cargo build`.

## Test plan
- [x] `cargo clean && cargo nextest run --verbose` succeeds (65 passed) with no prior build step.
- [x] `cargo publish` path is unchanged, still performs its own release build for the crates.io upload (only runs on push to master, gated by the existing `if` condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)